### PR TITLE
documentation fix for issue #31

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -21,7 +21,7 @@ Date : 13 July 2011
 Windows => Use precompiled binary, or compile it with VS2008/2010 (Express or pro, Pro will allow you to enable Opemp in CMVS)
         => Use CMake GUI in order to generate the Visual Studio project file (in ./program you will find the main CMakeLists.txt).
 
-Linux => use makefile in program/main.
+Linux => use makefile in program.
 
  Or use CMake build system :
 => Install the following libraries : jpeg boost boost-graph


### PR DESCRIPTION
Readme.txt file indicates Linux compilation must done in program/main. But it leads to compilation error. Compiling in program creates no errors. This problem was also pointed in issue  #21