### PR TITLE
Fix nondeterminism due to uninitialized memory

### DIFF
--- a/program/base/pmvs/patch.h
+++ b/program/base/pmvs/patch.h
@@ -17,6 +17,14 @@ class Cpatch {
     // dflag is initialized only once. if failed in one direction, we
     // never try that.
     m_dflag = 0;
+
+    // All non-class member variables need to be initialized so that
+    // they aren't just uninitialized memory.
+    m_flag = 0;
+    m_id = 0;
+    m_dscale = 0;
+    m_ascale = 0;
+    m_tmp = 0;
   }
   
   //----------------------------------------------------------------------


### PR DESCRIPTION
Fixes #35.

The `Patch` class does not initialise various fields, most importantly
not `float m_dscale`, which is used e.g. in numeric optimizations.

It is set in "CpatchOrganizerS::setScales" but that setting uses only
`+=`, `/=` and so on, thus depending on the previous value.
This works "out of luck" in most cases because the memory for patches
are re-used and the final `m_dscale` of the previous patch often
happens to be close to 0.

This change makes my testing invocation of pmvs2 valgrind-clean,
while before it would immediately warn about use of unititialized
values.