### PR TITLE
cmvs: Fix nondeterminism due to uninitialised memory in compute_bounding_box

### DIFF
--- a/program/base/stann/sep_float.hpp
+++ b/program/base/stann/sep_float.hpp
@@ -29,28 +29,6 @@
 */
 using namespace std;
 
-/*
-template< class T=sep_float<double> >
-class numeric_limits
-{
-public:
-  static const bool is_specialized = true;
-  static double max() throw() {return numeric_limits<double>::max();}
-  static double min() throw() {return -numeric_limits<double>::max();}
-
-};
-
-template< class T=sep_float<long double> >
-class numeric_limits
-{
-public:
-  static const bool is_specialized = true;
-  static long double max() throw() {return numeric_limits<long double>::max();}
-  static long double min() throw() {return -numeric_limits<long double>::max();}
-
-};*/
-
-
 //! Seperated float significand
 /*! 
   This union stores a seperated float significand.
@@ -221,5 +199,28 @@ private:
 };
 
 
+template<> class std::numeric_limits < sep_float<float> >
+{
+public:
+  static const bool is_specialized = true;
+  static float max() throw() {return numeric_limits<float>::max();}
+  static float min() throw() {return -numeric_limits<float>::max();}
+};
+
+template<> class std::numeric_limits < sep_float<double> >
+{
+public:
+  static const bool is_specialized = true;
+  static double max() throw() {return numeric_limits<double>::max();}
+  static double min() throw() {return -numeric_limits<double>::max();}
+};
+
+template<> class std::numeric_limits < sep_float<long double> >
+{
+public:
+  static const bool is_specialized = true;
+  static long double max() throw() {return numeric_limits<long double>::max();}
+  static long double min() throw() {return -numeric_limits<long double>::max();}
+};
 
 #endif

--- a/program/base/stann/sep_float.hpp
+++ b/program/base/stann/sep_float.hpp
@@ -193,9 +193,9 @@ private:
     exp   = x.exp;
     val   = x.val;
   }
-  sep_float_sig<FLT> sig;
-  int                exp;
-  FLT                val;
+  sep_float_sig<FLT> sig; // = { .d = 0 }; // needs to be initialized in constructor because it's a union
+  int                exp; // = 0;
+  FLT                val; // = 0;
 };
 
 


### PR DESCRIPTION
Similar as for `pmvs2` in #37, `cmvs` is nondeterministic due to use of uninitialised memory.

---

Due to lack of `std::numeric_limits` implementations for `sep_float`
(most commonly observed, `sep_float<float>`), the `min` and `max` members
in the `sfcnn_work` class were until now initialised to the `sep_float()`
constructor, instead of a proper minimum/maximum float value.

Worse still, the `sep_float()` constructor does not even initialise
its primitive class members, which thus are uninitialised memory.
These uninitialised values are then used in comparisons in
`sfcnn_work<Point>::compute_bounding_box()`.

This results in nondeterministic behaviour when running cmvs.

It is also immediately pointed out by `valgrind`:

    Conditional jump or move depends on uninitialised value(s)
       at 0x567D578: frexp (in glibc-2.26-131/lib/libm-2.26.so)
       by 0x41F6FE: msdb (sep_float.hpp:127)
       by 0x41F6FE: zorder_lt_worker<reviver::dpoint<sep_float<float>, 3u>, sep_float<float>, zorder_t, zorder_f, zorder_t>::lt_func(reviver::dpoint<sep_float<float>, 3u> const&, reviver::dpoint<sep_float<float>, 3u> const&) (zorder_lt.hpp:240)
       by 0x42056B: operator() (zorder_lt.hpp:189)
       by 0x42056B: operator() (zorder_lt.hpp:262)
       by 0x42056B: sfcnn_work<reviver::dpoint<sep_float<float>, 3u> >::ksearch_common(reviver::dpoint<sep_float<float>, 3u>, unsigned int, unsigned long, qknn&, float) (sfcnn.hpp:251)
       by 0x420B2F: sfcnn_work<reviver::dpoint<sep_float<float>, 3u> >::ksearch(reviver::dpoint<sep_float<float>, 3u>, unsigned int, std::vector<unsigned long, std::allocator<unsigned long> >&, std::vector<double, std::allocator<double> >&, float) (sfcnn.hpp:287)
       by 0x41553A: ksearch (sfcnn.hpp:397)
       by 0x41553A: CMVS::Cbundle::findPNeighbors(sfcnn<float const*, 3u, float>&, int, std::vector<int, std::allocator<int> >&) (bundle.cc:640)
       by 0x415803: CMVS::Cbundle::mergeSfMPThread() (bundle.cc:687)
       by 0x416088: CMVS::Cbundle::mergeSfMPThreadTmp(void*) (bundle.cc:725)
       by 0x47C066: _thrd_wrapper_function (tinycthread.c:341)
       by 0x4E402A6: start_thread (in glibc-2.26-131/lib/libpthread-2.26.so)
       by 0x5C9157E: clone (in glibc-2.26-131/lib/libc-2.26.so)
     Uninitialised value was created by a stack allocation
       at 0x4706D4: sfcnn_work<reviver::dpoint<sep_float<float>, 3u> >::sfcnn_work_init(int) (sfcnn.hpp:119)

This PR fixes the problem by providing `std::numeric_limits` `min()` and
`max()` implementations (as the previously commented-out code *almost*
provided correctly; however it lacked the `<float>` instance).

It also fixes the problem that the `sep_float` class members are not initialised (which doesn't seem to be required for further `valgrind`-clean-ness at least in my invocation, but is generally good).

As a safety check against issues like this, I also add a
runtime check, throwing if `numeric_limits` does not work as expected.